### PR TITLE
build from source archives instead of git clone

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -1,32 +1,17 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  url "https://github.com/cockroachdb/cockroach.git",
-      :tag => "beta-20170330"
+  version "beta-20170330"
+  url "https://binaries.cockroachdb.com/cockroach-beta-20170330.src.tgz"
+  sha256 "578335950bd22b773f91cf8a30ebd8aa3906e8970c903aa1b04c737b2109a442"
   head "https://github.com/cockroachdb/cockroach.git"
 
   depends_on "go" => :build
 
   def install
-    # Move everything in the current directory (i.e. the cockroach
-    # repo), except for .brew_home, to where it would reside in a
-    # normal Go source layout.
-    files = Dir.glob("*") + Dir.glob(".[a-z]*")
-    files.delete(".brew_home")
-    mkdir_p buildpath/"src/github.com/cockroachdb/cockroach"
-    mv files, buildpath/"src/github.com/cockroachdb/cockroach"
-
-    # The only go binary we need to install is glock.
-    ENV["GOBIN"] = buildpath/"bin"
     ENV["GOPATH"] = buildpath
-    ENV["GOHOME"] = buildpath
-
-    # We use `xcrun make` instead of `make` to avoid homebrew mucking
-    # with the HOMEBREW_CCCFG variable which in turn causes the C
-    # compiler to behave in a way that is not supported by cgo.
-    system "xcrun", "make", "GOFLAGS=-v", "-C",
-           "src/github.com/cockroachdb/cockroach", "build"
-    bin.install "src/github.com/cockroachdb/cockroach/cockroach" => "cockroach"
+    system "make", "install"
+    bin.install "bin/cockroach" => "cockroach"
 
     # TODO(pmattis): Debug the launchctl stuff
     # (prefix+'com.cockroachlabs.cockroachdb.plist').write startup_plist


### PR DESCRIPTION
See cockroachdb/cockroach#14031 for context. Cockroach now publishes
source archives as part of the release process. These archives have
several advantages:

    * Source archives are much smaller than a full Git clone of our
      repository, which is advantageous for developers who want to build
      from source but don't plan to hack on Cockroach.

    * Homebrew strongly prefers source archives, which are easily
      checksummed, to Git clones, which have mutable tags.

    * The source archive is laid out to facilitate easy building from
      source, which is reflected by the drastic simplification of this
      Homebrew recipe.

This commit points the formula at the new source archive instead of the
Git repository and adjusts the build recipe accordingly.