### PR TITLE
add launchd configuration to support brew services

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -12,16 +12,47 @@ class Cockroach < Formula
     ENV["GOPATH"] = buildpath
     system "make", "install"
     bin.install "bin/cockroach" => "cockroach"
-
-    # TODO(pmattis): Debug the launchctl stuff
-    # (prefix+'com.cockroachlabs.cockroachdb.plist').write startup_plist
-    # (prefix+'com.cockroachlabs.cockroachdb.plist').chmod 0644
   end
 
-  def caveats
-    <<-EOS.undent
-    Start the cockroach server:
-        cockroach start --store=#{var}/cockroach
+  def caveats; <<-EOS.undent
+    CockroachDB is a distributed database intended for multi-server deployments.
+    For local development only, this formula ships a launchd configuration to
+    start a single-node cluster that stores its data under:
+      #{var}/cockroach/
+    Instead of the default port of 8080, the node serves its admin UI at:
+      #{Formatter.url('http://localhost:26256')}
+
+    Do NOT use this cluster to store data you care about; it runs in insecure
+    mode and may expose data publicly in e.g. a DNS rebinding attack. To run
+    CockroachDB securely, please see:
+      #{Formatter.url('https://www.cockroachlabs.com/docs/secure-a-cluster.html')}
+    EOS
+  end
+
+  plist_options :manual => "cockroach start"
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/cockroach</string>
+        <string>start</string>
+        <string>--store=#{var}/cockroach/</string>
+        <string>--http-port=26256</string>
+      </array>
+      <key>WorkingDirectory</key>
+      <string>#{var}</string>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <true/>
+    </dict>
+    </plist>
     EOS
   end
 
@@ -44,34 +75,4 @@ class Cockroach < Formula
       system "#{bin}/cockroach", "quit"
     end
   end
-
-  #   def startup_plist
-  #     return <<-EOS
-  # <?xml version="1.0" encoding="UTF-8"?>
-  # <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-  # <plist version="1.0">
-  # <dict>
-  #   <key>Label</key>
-  #   <string>com.cockroachlabs.cockroachdb</string>
-  #   <key>ProgramArguments</key>
-  #   <array>
-  #     <string>#{bin}/cockroach</string>
-  #     <string>start</string>
-  #   </array>
-  #   <key>RunAtLoad</key>
-  #   <true/>
-  #   <key>KeepAlive</key>
-  #   <false/>
-  #   <key>UserName</key>
-  #   <string>#{`whoami`.chomp}</string>
-  #   <key>WorkingDirectory</key>
-  #   <string>#{HOMEBREW_PREFIX}</string>
-  #   <key>StandardErrorPath</key>
-  #   <string>#{var}/log/cockroachdb/output.log</string>
-  #   <key>StandardOutPath</key>
-  #   <string>#{var}/log/cockroachdb/output.log</string>
-  # </dict>
-  # </plist>
-  # EOS
-  #   end
 end


### PR DESCRIPTION
Add a launchd configuration so that brew services can manage a single-node Cockroach cluster, if so desired.

Fixes cockroachdb/cockroach#9438.

---

This supersedes #1, which is inexplicably ignoring my force pushes. @bdarnell, I've updated the formula to serve the admin on port 26256, as discussed, and added a caveat reminding users to only use this configuration in development. The full caveats read:

```
==> Caveats
CockroachDB is a distributed database intended for multi-server deployments.
For local development only, this formula ships a launchd configuration to
start an insecure single-node cluster that stores its data under:
  /usr/local/var/cockroach/
Instead of the default port of 8080, the node serves its admin UI at:
  http://localhost:26256

To run CockroachDB in production, please see:
  https://www.cockroachlabs.com/docs/recommended-production-settings.html

To have launchd start cockroachdb/cockroach/cockroach now and restart at login:
  brew services start cockroachdb/cockroach/cockroach
Or, if you don't want/need a background service you can just run:
  cockroach start

```

The last four lines are added automatically when a plist is present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/homebrew-cockroach/6)
<!-- Reviewable:end -->
