### PR TITLE
cockroach: support building with Xcode 8.3

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -10,7 +10,7 @@ class Cockroach < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    system "make", "install"
+    system "make", "install", "LINKFLAGS=-s"
     bin.install "bin/cockroach" => "cockroach"
   end
 


### PR DESCRIPTION
Binaries built with Xcode 8.3 immediately fail to execute with `Killed:
9`. See golang/go#19734 for details. The workaround is to pass `-ldflags
-s`; this commit accomplishes that by building with `LINKFLAGS=-s`.

Fixes #7.