### PR TITLE
cockroach: pass --insecure when launching service

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -48,6 +48,8 @@ class Cockroach < Formula
         <string>start</string>
         <string>--store=#{var}/cockroach/</string>
         <string>--http-port=26256</string>
+        <string>--insecure</string>
+        <string>--host=localhost</string>
       </array>
       <key>WorkingDirectory</key>
       <string>#{var}</string>


### PR DESCRIPTION
We've always started CockroachDB insecurely; see #6 for a discussion of why this is reasonable. As of cockroachdb/cockroach#14703, however, we must explicitly pass --insecure; running `cockroach start` without either a cert directory or an explicit --insecure opt-in is an error.