### PR TITLE
make deprecation warning less ominous

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Homebrew CockroachDB
 
-🚫 **THIS REPOSITORY IS DEPRECATED.** 🚫
+🎉 **[CockroachDB] is now included in Homebrew core.** 🎉
 
-[CockroachDB] is now included in Homebrew core. If you never installed
-[CockroachDB] from this tap, you can install directly from Homebrew:
+If you never installed [CockroachDB] from this tap, you can install directly from Homebrew:
 
 ```shell
 $ brew install cockroach


### PR DESCRIPTION
The big red warning signs 🚫 led people to believe that Homebrew was no longer a
supported installation method for CockroachDB. Make the deprecation warning less
obvious to avoid confusing would-be users.