### PR TITLE
Revive our custom tap

### DIFF
--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -4,6 +4,9 @@ class Cockroach < Formula
   url "https://binaries.cockroachdb.com/cockroach-v19.1.4.darwin-10.9-amd64.tgz"
   version "19.1.4"
   sha256 "6911796049865aa1c27d11904893ea6f7a031bdfe90f531a4ea510fde3568439"
+  # This revision facilitates conversion from homebrew-core to the tap.
+  # TODO(bdarnell): Remove this once we've updated to a version that never appeared in homebrew-core.
+  revision 1
 
   bottle :unneeded
 

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -9,6 +9,10 @@ class Cockroach < Formula
 
   def install
     bin.install "cockroach"
+    system "#{bin}/cockroach gen man --path=#{man1}"
+    system "mkdir -p #{bash_completion} #{zsh_completion}"
+    system "#{bin}/cockroach gen autocomplete bash --out=#{bash_completion}/cockroach"
+    system "#{bin}/cockroach gen autocomplete zsh --out=#{zsh_completion}/_cockroach"
   end
 
   def caveats; <<~EOS

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -12,10 +12,13 @@ class Cockroach < Formula
 
   def install
     bin.install "cockroach"
-    system "#{bin}/cockroach gen man --path=#{man1}"
-    system "mkdir -p #{bash_completion} #{zsh_completion}"
-    system "#{bin}/cockroach gen autocomplete bash --out=#{bash_completion}/cockroach"
-    system "#{bin}/cockroach gen autocomplete zsh --out=#{zsh_completion}/_cockroach"
+    system "#{bin}/cockroach", "gen", "man", "--path=#{man1}"
+
+    bash_completion.mkpath
+    system "#{bin}/cockroach", "gen", "autocomplete", "bash", "--out=#{bash_completion}/cockroach"
+
+    zsh_completion.mkpath
+    system "#{bin}/cockroach", "gen", "autocomplete", "zsh", "--out=#{zsh_completion}/_cockroach"
   end
 
   def caveats; <<~EOS
@@ -66,7 +69,7 @@ class Cockroach < Formula
       # Redirect stdout and stderr to a file, or else  `brew test --verbose`
       # will hang forever as it waits for stdout and stderr to close.
       # TODO(bdarnell): this mkfifo will be unnecessary in 19.2 (#39300)
-      system "mkfifo listen_url_fifo"
+      system "mkfifo", "listen_url_fifo"
       system "#{bin}/cockroach start --insecure --background --listen-addr=127.0.0.1:0 --http-addr=127.0.0.1:0 --listening-url-file=listen_url_fifo&> start.out"
       # TODO(bdarnell): remove the X from this variable and the --url flags after
       # https://github.com/cockroachdb/cockroach/issues/40747 is fixed.
@@ -92,7 +95,7 @@ class Cockroach < Formula
       end
       raise e
     ensure
-      system "#{bin}/cockroach quit --url=$XCOCKROACH_URL"
+      system "#{bin}/cockroach", "quit", "--url=$XCOCKROACH_URL"
     end
   end
 end

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -1,42 +1,51 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  version "1.0"
-  revision 1
-  url "https://binaries.cockroachdb.com/cockroach-v1.0.src.tgz"
-  sha256 "ca87b10eec688195e0df4f85431b019f2980ae4b511ee321f91f945315efeb76"
+  url "https://binaries.cockroachdb.com/cockroach-v19.1.4.src.tgz"
+  version "19.1.4"
+  sha256 "d819167dc109b566511cb6cef9aadc8c4f07b1be6a8b3108f4bbd14808d21faf"
   head "https://github.com/cockroachdb/cockroach.git"
 
-  def install
-    raise <<-EOS.undent
-      The CockroachDB formula has moved into Homebrew proper.
-      Please instead run:
-
-          $ brew uninstall cockroachdb/cockroach/cockroach
-          $ brew untap cockroachdb/cockroach
-          $ brew install cockroach
-
-    EOS
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "82d20462ca26fcdaad2c4639582bc3cbb10fee2ca9fb63d1944648dc9fdf461a" => :mojave
+    sha256 "247cea9630fdc06c497c42ccf6290b601870eaac96a14ec91a993e87bbf5acb1" => :high_sierra
+    sha256 "f55c8f203ff3c49312641f81d7a15c4f3bcc02c5a5585981574b11161eeda62d" => :sierra
   end
 
-  def caveats; <<-EOS.undent
-    CockroachDB is a distributed database intended for multi-server deployments.
+  depends_on "autoconf" => :build
+  depends_on "cmake" => :build
+  depends_on "go" => :build
+  depends_on "make" => :build
+  depends_on "xz" => :build
+
+  def install
+    # The GNU Make that ships with macOS Mojave (v3.81 at the time of writing) has a bug
+    # that causes it to loop infinitely when trying to build cockroach. Use
+    # the more up-to-date make that Homebrew provides.
+    ENV.prepend_path "PATH", Formula["make"].opt_libexec/"gnubin"
+    # Build only the OSS components
+    system "make", "buildoss"
+    system "make", "install", "prefix=#{prefix}", "BUILDTYPE=release"
+  end
+
+  def caveats; <<~EOS
     For local development only, this formula ships a launchd configuration to
     start a single-node cluster that stores its data under:
       #{var}/cockroach/
     Instead of the default port of 8080, the node serves its admin UI at:
-      #{Formatter.url('http://localhost:26256')}
+      #{Formatter.url("http://localhost:26256")}
 
     Do NOT use this cluster to store data you care about; it runs in insecure
     mode and may expose data publicly in e.g. a DNS rebinding attack. To run
     CockroachDB securely, please see:
-      #{Formatter.url('https://www.cockroachlabs.com/docs/secure-a-cluster.html')}
-    EOS
+      #{Formatter.url("https://www.cockroachlabs.com/docs/secure-a-cluster.html")}
+  EOS
   end
 
   plist_options :manual => "cockroach start --insecure"
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">
@@ -60,24 +69,34 @@ class Cockroach < Formula
       <true/>
     </dict>
     </plist>
-    EOS
+  EOS
   end
 
   test do
     begin
-      system "#{bin}/cockroach", "start", "--insecure", "--background"
-      pipe_output("#{bin}/cockroach sql --insecure", <<-EOS.undent)
+      # Redirect stdout and stderr to a file, or else  `brew test --verbose`
+      # will hang forever as it waits for stdout and stderr to close.
+      system "#{bin}/cockroach start --insecure --background &> start.out"
+      pipe_output("#{bin}/cockroach sql --insecure", <<~EOS)
         CREATE DATABASE bank;
         CREATE TABLE bank.accounts (id INT PRIMARY KEY, balance DECIMAL);
         INSERT INTO bank.accounts VALUES (1, 1000.50);
       EOS
       output = pipe_output("#{bin}/cockroach sql --insecure --format=csv",
         "SELECT * FROM bank.accounts;")
-      assert_equal <<-EOS.undent, output
-        1 row
+      assert_equal <<~EOS, output
         id,balance
         1,1000.50
       EOS
+    rescue => e
+      # If an error occurs, attempt to print out any messages from the
+      # server.
+      begin
+        $stderr.puts "server messages:", File.read("start.out")
+      rescue
+        $stderr.puts "unable to load messages from start.out"
+      end
+      raise e
     ensure
       system "#{bin}/cockroach", "quit", "--insecure"
     end

--- a/Formula/cockroach.rb
+++ b/Formula/cockroach.rb
@@ -1,32 +1,14 @@
 class Cockroach < Formula
   desc "Distributed SQL database"
   homepage "https://www.cockroachlabs.com"
-  url "https://binaries.cockroachdb.com/cockroach-v19.1.4.src.tgz"
+  url "https://binaries.cockroachdb.com/cockroach-v19.1.4.darwin-10.9-amd64.tgz"
   version "19.1.4"
-  sha256 "d819167dc109b566511cb6cef9aadc8c4f07b1be6a8b3108f4bbd14808d21faf"
-  head "https://github.com/cockroachdb/cockroach.git"
+  sha256 "6911796049865aa1c27d11904893ea6f7a031bdfe90f531a4ea510fde3568439"
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "82d20462ca26fcdaad2c4639582bc3cbb10fee2ca9fb63d1944648dc9fdf461a" => :mojave
-    sha256 "247cea9630fdc06c497c42ccf6290b601870eaac96a14ec91a993e87bbf5acb1" => :high_sierra
-    sha256 "f55c8f203ff3c49312641f81d7a15c4f3bcc02c5a5585981574b11161eeda62d" => :sierra
-  end
-
-  depends_on "autoconf" => :build
-  depends_on "cmake" => :build
-  depends_on "go" => :build
-  depends_on "make" => :build
-  depends_on "xz" => :build
+  bottle :unneeded
 
   def install
-    # The GNU Make that ships with macOS Mojave (v3.81 at the time of writing) has a bug
-    # that causes it to loop infinitely when trying to build cockroach. Use
-    # the more up-to-date make that Homebrew provides.
-    ENV.prepend_path "PATH", Formula["make"].opt_libexec/"gnubin"
-    # Build only the OSS components
-    system "make", "buildoss"
-    system "make", "install", "prefix=#{prefix}", "BUILDTYPE=release"
+    bin.install "cockroach"
   end
 
   def caveats; <<~EOS

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
-# Homebrew CockroachDB
+# CockroachDB Homebrew Tap
 
-🎉 **[CockroachDB] is now included in Homebrew core.** 🎉
+This is the offical source for installing CockroachDB with Homebrew.
 
-If you never installed [CockroachDB] from this tap, you can install directly from Homebrew:
+## Installing
 
 ```shell
-$ brew install cockroach
+$ brew install cockroachdb/cockroach/cockroach
 ```
 
-Otherwise, remove this tap, then re-install from Homebrew core:
+Alternately, you can configure the tap and install the package separately:
 
-```shell
-$ brew uninstall cockroachdb/cockroach/cockroach
-$ brew untap cockroachdb/cockroach
+``` shell
+$ brew tap cockroachdb/cockroach
 $ brew install cockroach
 ```
 


### PR DESCRIPTION
Due to the move to the BSL, CockroachDB 19.2 will no longer be eligible for inclusion in `homebrew-core`. Bring this tap back up to date so we can recommend it instead.

Use our binary releases instead of building from source (a `homebrew-core` requirement) to avoid potential issues relating to `go` or other C dependency versions. 

Also add some new features: man pages and shell completion files are now installed. 

Fixes cockroachdb/cockroach#35657